### PR TITLE
Show already voted status frontend

### DIFF
--- a/src/main/resources/js/src/lib/cookie.js
+++ b/src/main/resources/js/src/lib/cookie.js
@@ -1,0 +1,5 @@
+export function getCookie(name) {
+  const regexp = new RegExp(`(?:^${name}|;\s*${name})=(.*?)(?:;|$)`, "g");
+  const result = regexp.exec(document.cookie);
+  return (result === null) ? null : result[1];
+}

--- a/src/main/resources/js/src/lib/social.js
+++ b/src/main/resources/js/src/lib/social.js
@@ -2,6 +2,7 @@
 function copyStuff(button, output) {
 	let range = document.createRange();
 	range.selectNode(output);
+	window.getSelection().removeAllRanges();
 	window.getSelection().addRange(range);
 
 	try {

--- a/src/main/resources/js/src/vote.js
+++ b/src/main/resources/js/src/vote.js
@@ -1,3 +1,14 @@
 import {addCopy} from './lib/social';
+import {getCookie} from './lib/cookie';
 
 addCopy(decodeURIComponent(document.URL), '#social');
+
+const slug = location.pathname.split('/')[1];
+if (getCookie('pollistics-voted').includes(slug)) {
+    const info = document.createElement('p');
+    info.innerHTML = `<strong>Oops</strong>, you already voted for this poll. Check out the <a href="https://pollistics.com/${slug}/results">results</a>`;
+    info.className = 'message error';
+    info.style.marginLeft = 0;
+    info.style.marginRight = 0;
+    document.querySelector('.vote--container').appendChild(info);
+}


### PR DESCRIPTION
If you already voted, you should be directed to look at the results
instead.

Should we show the link to the results at all times?

merged in with this request: a bugfix for social sharing, it would not
work if you previously selected something in a page because it didn't
clear your selection.

![capture](https://cloud.githubusercontent.com/assets/6270048/21451958/a6bfd960-c903-11e6-8167-3d37ad9c4be2.PNG)



